### PR TITLE
Feature: GitHub Models authentication for ArcGIS Pro AI Toolbox

### DIFF
--- a/arcgispro_ai.pyt
+++ b/arcgispro_ai.pyt
@@ -28,18 +28,6 @@ try:
 except AttributeError:
     ArcGISMapType = Any
 
-    get_client,
-    GeoJSONUtils,
-    parse_numeric_value,
-    get_env_var,
-    OpenAIClient,
-    OpenRouterClient,
-)
-    DEFAULT_OPENROUTER_MODELS,
-    VISION_MODEL_HINTS,
-    model_supports_images as _registry_model_supports_images,
-)
-
 ## Model registry is now in core/model_registry.py
 
 class MapUtils:
@@ -1053,6 +1041,13 @@ def get_feature_count_value(layer: str, sql_query: Optional[str] = None) -> int:
 
 def resolve_api_key(source: str, api_key_map: dict, tool_slug: str) -> str:
     """Fetch the API key for a provider, prompting the user if it is missing."""
+    if source == "GitHub Models":
+        try:
+            return load_github_models_token()
+        except ValueError as exc:
+            arcpy.AddError(str(exc))
+            raise
+
     env_var = api_key_map.get(source, "OPENROUTER_API_KEY")
     if env_var:
         api_key = get_env_var(env_var)
@@ -1085,7 +1080,13 @@ def update_model_parameters(source: str, parameters: list, current_model: Option
         },
         "OpenRouter": {
             "models": [],  # populated dynamically
-            "default": "openai/gpt-4o-mini",
+            "default": "openai/gpt-4o",
+            "endpoint": False,
+            "deployment": False,
+        },
+        "GitHub Models": {
+            "models": DEFAULT_GITHUB_MODELS,
+            "default": "openai/gpt-4.1",
             "endpoint": False,
             "deployment": False,
         },
@@ -1133,14 +1134,31 @@ def update_model_parameters(source: str, parameters: list, current_model: Option
             config["models"] = client.get_available_models()
         except Exception:
             config["models"] = DEFAULT_OPENROUTER_MODELS
+    elif source == "GitHub Models":
+        try:
+            token = load_github_models_token()
+            client = GitHubModelsClient(token)
+            config["models"] = client.get_available_models()
+        except Exception:
+            config["models"] = DEFAULT_GITHUB_MODELS
 
     # Model parameter
-    parameters[1].enabled = bool(config["models"])
+    allow_custom_model = source in ("OpenRouter", "GitHub Models")
+    parameters[1].enabled = bool(config["models"]) or allow_custom_model
     if config["models"]:
-        parameters[1].filter.type = "ValueList"
-        parameters[1].filter.list = config["models"]
-        if not current_model or current_model not in config["models"]:
-            parameters[1].value = config["default"]
+        if allow_custom_model and current_model and current_model not in config["models"]:
+            parameters[1].filter.type = "None"
+            parameters[1].filter.list = []
+            parameters[1].value = current_model
+        else:
+            parameters[1].filter.type = "ValueList"
+            parameters[1].filter.list = config["models"]
+            if not current_model:
+                parameters[1].value = config["default"]
+            elif current_model in config["models"]:
+                parameters[1].value = current_model
+            else:
+                parameters[1].value = config["default"]
 
     # Endpoint parameter
     parameters[2].enabled = config["endpoint"]
@@ -1153,6 +1171,38 @@ def update_model_parameters(source: str, parameters: list, current_model: Option
 def model_supports_images(source: str, model: Optional[str] = None) -> bool:
     """Compatibility shim: delegate to core.model_registry.model_supports_images."""
     return _registry_model_supports_images(source, model)
+
+from pathlib import Path
+
+DEFAULT_CONFIG_DIR = Path.home() / ".arcgispro_ai"
+DEFAULT_GITHUB_MODELS_TOKEN_FILE = DEFAULT_CONFIG_DIR / "github_models_token.txt"
+TOKEN_SETUP_GUIDANCE = (
+    "GitHub Models token not found. Run tools\\auth\\auth_github_models.bat "
+    "to configure authentication."
+)
+
+def get_github_models_token_path() -> Path:
+    """Return the configured GitHub Models token file path."""
+    override = os.environ.get("ARCGISPRO_AI_GITHUB_MODELS_TOKEN_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_GITHUB_MODELS_TOKEN_FILE
+
+def load_github_models_token(token_path: Optional[str] = None) -> str:
+    """Load the locally stored GitHub Models token."""
+    path = Path(token_path).expanduser() if token_path else get_github_models_token_path()
+
+    try:
+        token_value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise ValueError(TOKEN_SETUP_GUIDANCE) from exc
+    except OSError as exc:
+        raise ValueError(f"Unable to read GitHub Models token file at {path}: {exc}") from exc
+
+    if not token_value:
+        raise ValueError(TOKEN_SETUP_GUIDANCE)
+
+    return token_value
 
 import requests
 import xml.etree.ElementTree as ET
@@ -1353,7 +1403,7 @@ class DeepSeekClient(APIClient):
         return response["choices"][0]["message"]["content"].strip()
 
 class OpenRouterClient(APIClient):
-    def __init__(self, api_key: str, model: str = "openai/gpt-4o-mini"):
+    def __init__(self, api_key: str, model: str = "openai/gpt-4o"):
         super().__init__(api_key, "https://openrouter.ai/api/v1")
         self.model = model
         # Add OpenRouter-specific headers
@@ -1364,13 +1414,7 @@ class OpenRouterClient(APIClient):
 
     def get_available_models(self) -> List[str]:
         """Get list of available models from OpenRouter API."""
-        fallback_models = [
-            "openai/gpt-4o-mini",
-            "openai/o3-mini",
-            "google/gemini-2.0-flash-exp:free",
-            "anthropic/claude-3.5-sonnet",
-            "deepseek/deepseek-chat"
-        ]
+        fallback_models = DEFAULT_OPENROUTER_MODELS
         try:
             response = requests.get(
                 f"{self.base_url}/models",
@@ -1380,37 +1424,20 @@ class OpenRouterClient(APIClient):
             )
             response.raise_for_status()
             data = response.json().get("data", [])
-            models_with_meta = []
+            available_ids = set()
             for model in data:
                 model_id = model.get("id")
                 if not model_id:
                     continue
-                pricing = model.get("pricing", {})
-                prompt_price = pricing.get("prompt")
-                completion_price = pricing.get("completion")
+                available_ids.add(model_id)
 
-                def _parse_price(value: Any) -> float:
-                    if value in (None, "", "N/A"):
-                        return float("inf")
-                    try:
-                        return float(value)
-                    except (TypeError, ValueError):
-                        return float("inf")
-
-                models_with_meta.append(
-                    (
-                        model_id,
-                        _parse_price(prompt_price),
-                        _parse_price(completion_price)
-                    )
-                )
-
-            if not models_with_meta:
+            if not available_ids:
                 return fallback_models
 
-            # Sort with free models first, then by price, then alphabetically
-            models_with_meta.sort(key=lambda item: (item[1], item[2], item[0]))
-            return [model_id for model_id, _, _ in models_with_meta]
+            curated_available = [
+                model_id for model_id in fallback_models if model_id in available_ids
+            ]
+            return curated_available or fallback_models
         except Exception:
             return fallback_models
 
@@ -1543,7 +1570,8 @@ def get_client(source: str, api_key: str, **kwargs) -> APIClient:
         ),
         "Claude": lambda: ClaudeClient(api_key, model=kwargs.get('model', 'claude-3-opus-20240229')),
         "DeepSeek": lambda: DeepSeekClient(api_key, model=kwargs.get('model', 'deepseek-chat')),
-        "OpenRouter": lambda: OpenRouterClient(api_key, model=kwargs.get('model', 'openai/gpt-4o-mini')),
+        "OpenRouter": lambda: OpenRouterClient(api_key, model=kwargs.get('model', 'openai/gpt-4o')),
+        "GitHub Models": lambda: GitHubModelsClient(api_key, model=kwargs.get("model", "openai/gpt-4.1")),
         "Local LLM": lambda: LocalLLMClient(base_url=kwargs.get('base_url', 'http://localhost:8000')),
         "Wolfram Alpha": lambda: WolframAlphaClient(api_key)
     }
@@ -1560,23 +1588,60 @@ VISION_MODEL_HINTS = {
     "Azure OpenAI": ["gpt-4o", "gpt-4.1", "omni", "vision"],
     "OpenRouter": [
         "openai/gpt-4o",
-        "openai/gpt-4o-mini",
         "openai/gpt-4.1",
-        "google/gemini",
-        "anthropic/claude-3.5",
-        "anthropic/claude-3-opus",
+        "openai/gpt-5",
+        "google/gemini-2.5",
+        "google/gemini-3",
+        "anthropic/claude-4",
+        "anthropic/claude-4.5",
         "meta-llama/llama-3.2-vision",
+    ],
+    "GitHub Models": [
+        "gpt-4o",
+        "omni",
+        "vision",
+        "llama-3.2-vision",
     ],
 }
 
-# Fallback short list for OpenRouter if dynamic catalog fetch fails
-DEFAULT_OPENROUTER_MODELS = [
-    "openai/gpt-4o-mini",
-    "openai/o3-mini",
-    "google/gemini-2.0-flash-exp:free",
-    "anthropic/claude-3.5-sonnet",
-    "deepseek/deepseek-chat",
+# Curated OpenRouter model list aligned with the Copilot-style picker.
+OPENROUTER_CURATED_MODELS = [
+    "openai/gpt-4.1",
+    "openai/gpt-4o",
+    "openai/gpt-5-mini",
+    "anthropic/claude-4.5-haiku",
+    "anthropic/claude-4.5-opus",
+    "anthropic/claude-4-sonnet",
+    "anthropic/claude-4.5-sonnet",
+    "google/gemini-2.5-pro",
+    "google/gemini-3-flash-preview",
+    "google/gemini-3-pro-preview",
+    "openai/gpt-5",
+    "openai/gpt-5-codex-preview",
+    "openai/gpt-5.1",
+    "openai/gpt-5.1-codex",
+    "openai/gpt-5.1-codex-max",
+    "openai/gpt-5.1-codex-mini-preview",
+    "openai/gpt-5.2",
+    "openai/gpt-5.2-codex",
 ]
+
+# Fallback short list for OpenRouter if dynamic catalog fetch fails
+DEFAULT_OPENROUTER_MODELS = OPENROUTER_CURATED_MODELS
+
+# Curated GitHub Models options for the toolbox picker.
+GITHUB_MODELS_CURATED_MODELS = [
+    "openai/gpt-4.1",
+    "openai/gpt-4.1-mini",
+    "openai/gpt-4o",
+    "openai/gpt-5-mini",
+    "deepseek/deepseek-r1",
+    "meta/llama-3.2-90b-vision-instruct",
+    "meta/llama-3.3-70b-instruct",
+]
+
+# Fallback short list for GitHub Models.
+DEFAULT_GITHUB_MODELS = GITHUB_MODELS_CURATED_MODELS
 
 def model_supports_images(source: str, model: Optional[str] = None) -> bool:
     """Return True if the selected model is known to accept image input.
@@ -1593,6 +1658,161 @@ def model_supports_images(source: str, model: Optional[str] = None) -> bool:
         return source in ("OpenAI", "Azure OpenAI")
 
     return any(hint in normalized for hint in provider_hints)
+
+import ssl
+from urllib import error, request
+
+class GitHubModelsClient:
+    """Client for GitHub Models chat completions."""
+
+    def __init__(
+        self,
+        token: str,
+        model: str = "openai/gpt-4.1",
+        endpoint: str = "https://models.github.ai/inference/chat/completions",
+    ):
+        self.token = token
+        self.model = model
+        self.endpoint = endpoint
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def get_available_models(self) -> List[str]:
+        """Get available models from GitHub Models catalog, ordered by curation."""
+        fallback_models = DEFAULT_GITHUB_MODELS
+        req = request.Request(
+            "https://models.github.ai/catalog/models",
+            headers={
+                "Authorization": self.headers["Authorization"],
+                "Accept": "application/json",
+                "X-GitHub-Api-Version": self.headers["X-GitHub-Api-Version"],
+            },
+            method="GET",
+        )
+        ssl_context = ssl.create_default_context()
+
+        try:
+            with request.urlopen(req, timeout=15, context=ssl_context) as response:
+                body = response.read().decode("utf-8")
+                payload = json.loads(body)
+        except Exception:
+            return fallback_models
+
+        if not isinstance(payload, list):
+            return fallback_models
+
+        available_ids = {
+            model.get("id")
+            for model in payload
+            if isinstance(model, dict) and model.get("id")
+        }
+        if not available_ids:
+            return fallback_models
+
+        curated_available = [
+            model_id for model_id in fallback_models if model_id in available_ids
+        ]
+        if curated_available:
+            return curated_available
+
+        # If catalog shape changes or curated IDs drift, still offer a small, stable list.
+        discovered = sorted(str(model_id) for model_id in available_ids if isinstance(model_id, str))
+        return discovered[:20] if discovered else fallback_models
+
+    @staticmethod
+    def _extract_text_content(response: Dict[str, Any]) -> str:
+        choices = response.get("choices", [])
+        if not choices:
+            raise Exception("GitHub Models returned no choices.")
+
+        message = choices[0].get("message", {})
+        content = message.get("content", "")
+
+        if isinstance(content, str):
+            return content.strip()
+
+        if isinstance(content, list):
+            chunks: List[str] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                text_value = item.get("text")
+                if isinstance(text_value, str) and text_value:
+                    chunks.append(text_value)
+            if chunks:
+                return "".join(chunks).strip()
+
+        raise Exception("GitHub Models response did not include text content.")
+
+    def _post_json(
+        self,
+        payload: Dict[str, Any],
+        max_retries: int = 3,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        encoded_payload = json.dumps(payload).encode("utf-8")
+        ssl_context = ssl.create_default_context()
+
+        for attempt in range(max_retries):
+            req = request.Request(
+                self.endpoint,
+                data=encoded_payload,
+                headers=self.headers,
+                method="POST",
+            )
+            try:
+                with request.urlopen(req, timeout=timeout_seconds, context=ssl_context) as response:
+                    body = response.read().decode("utf-8")
+                    return json.loads(body)
+            except error.HTTPError as exc:
+                detail = exc.read().decode("utf-8", errors="replace")
+                if attempt == max_retries - 1:
+                    raise Exception(
+                        f"GitHub Models request failed with status {exc.code}: {detail}"
+                    ) from exc
+            except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+                if attempt == max_retries - 1:
+                    raise Exception(
+                        f"GitHub Models request failed after {max_retries} attempts: {exc}"
+                    ) from exc
+
+            time.sleep(2 ** attempt)
+
+        raise Exception("GitHub Models request failed with an unknown error.")
+
+    def get_completion(
+        self,
+        messages: List[Dict[str, Any]],
+        response_format: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        token_limit = max_tokens if max_tokens is not None else 4096
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.5,
+            "max_tokens": token_limit,
+        }
+
+        if response_format == "json_object":
+            payload["response_format"] = {"type": "json_object"}
+
+        response = self._post_json(payload)
+        return self._extract_text_content(response)
+
+    def get_vision_completion(self, messages: List[Dict[str, Any]], max_tokens: int = 800) -> str:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.2,
+            "max_tokens": max_tokens,
+        }
+        response = self._post_json(payload)
+        return self._extract_text_content(response)
 # --- END INLINED UTILITY CODE ---
 
 TOOL_DOC_BASE_URL = "https://danmaps.github.io/arcgispro_ai/tools"
@@ -1641,7 +1861,7 @@ class FeatureLayer(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -1736,6 +1956,7 @@ class FeatureLayer(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -1785,7 +2006,7 @@ class Field(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM", "Wolfram Alpha"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM", "Wolfram Alpha"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -1950,6 +2171,7 @@ class Field(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None,
             "Wolfram Alpha": "WOLFRAM_ALPHA_API_KEY"
         }
@@ -2106,7 +2328,7 @@ class InterpretMap(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -2191,6 +2413,7 @@ class InterpretMap(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -2221,7 +2444,7 @@ class InterpretMap(object):
             return
 
         screenshot_info = context.get("screenshot") if context else None
-        provider_supports_vision = source in ("OpenAI", "Azure OpenAI", "OpenRouter")
+        provider_supports_vision = source in ("OpenAI", "Azure OpenAI", "OpenRouter", "GitHub Models")
         model_allows_vision = model_supports_images(source, model) if provider_supports_vision else False
         model_label = model or "current model"
         use_screenshot = bool(include_screenshot) and bool(screenshot_info) and provider_supports_vision and model_allows_vision
@@ -2326,7 +2549,7 @@ class Python(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -2456,6 +2679,7 @@ class Python(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -2539,8 +2763,6 @@ class Python(object):
         """This method takes place after outputs are processed and
         added to the display."""
         return
-    
-
 class ConvertTextToNumeric(object):
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
@@ -2559,7 +2781,7 @@ class ConvertTextToNumeric(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -2689,6 +2911,7 @@ class ConvertTextToNumeric(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -2767,7 +2990,7 @@ class GenerateTool(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -2997,6 +3220,7 @@ class GenerateTool(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -3132,3 +3356,4 @@ Requirements:
         """This method takes place after outputs are processed and
         added to the display."""
         return
+

--- a/arcgispro_ai/auth.py
+++ b/arcgispro_ai/auth.py
@@ -1,0 +1,1 @@
+from arcgispro_ai.toolboxes.arcgispro_ai.auth import *

--- a/arcgispro_ai/providers/__init__.py
+++ b/arcgispro_ai/providers/__init__.py
@@ -1,0 +1,1 @@
+from .github_models import *

--- a/arcgispro_ai/providers/github_models.py
+++ b/arcgispro_ai/providers/github_models.py
@@ -1,0 +1,1 @@
+from arcgispro_ai.toolboxes.arcgispro_ai.providers.github_models import *

--- a/arcgispro_ai/toolboxes/arcgispro_ai/arcgispro_ai_utils.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/arcgispro_ai_utils.py
@@ -15,19 +15,9 @@ try:
 except AttributeError:
     ArcGISMapType = Any
 
-from .core.api_clients import (
-    get_client,
-    GeoJSONUtils,
-    parse_numeric_value,
-    get_env_var,
-    OpenAIClient,
-    OpenRouterClient,
-)
-from .core.model_registry import (
-    DEFAULT_OPENROUTER_MODELS,
-    VISION_MODEL_HINTS,
-    model_supports_images as _registry_model_supports_images,
-)
+from .core.api_clients import get_client, GeoJSONUtils, parse_numeric_value, get_env_var, OpenAIClient, OpenRouterClient, GitHubModelsClient
+from .auth import load_github_models_token
+from .core.model_registry import DEFAULT_GITHUB_MODELS, DEFAULT_OPENROUTER_MODELS, VISION_MODEL_HINTS, model_supports_images as _registry_model_supports_images
 
 ## Model registry is now in core/model_registry.py
 
@@ -1056,6 +1046,13 @@ def get_feature_count_value(layer: str, sql_query: Optional[str] = None) -> int:
 
 def resolve_api_key(source: str, api_key_map: dict, tool_slug: str) -> str:
     """Fetch the API key for a provider, prompting the user if it is missing."""
+    if source == "GitHub Models":
+        try:
+            return load_github_models_token()
+        except ValueError as exc:
+            arcpy.AddError(str(exc))
+            raise
+
     env_var = api_key_map.get(source, "OPENROUTER_API_KEY")
     if env_var:
         api_key = get_env_var(env_var)
@@ -1090,6 +1087,12 @@ def update_model_parameters(source: str, parameters: list, current_model: Option
         "OpenRouter": {
             "models": [],  # populated dynamically
             "default": "openai/gpt-4o",
+            "endpoint": False,
+            "deployment": False,
+        },
+        "GitHub Models": {
+            "models": DEFAULT_GITHUB_MODELS,
+            "default": "openai/gpt-4.1",
             "endpoint": False,
             "deployment": False,
         },
@@ -1137,9 +1140,16 @@ def update_model_parameters(source: str, parameters: list, current_model: Option
             config["models"] = client.get_available_models()
         except Exception:
             config["models"] = DEFAULT_OPENROUTER_MODELS
+    elif source == "GitHub Models":
+        try:
+            token = load_github_models_token()
+            client = GitHubModelsClient(token)
+            config["models"] = client.get_available_models()
+        except Exception:
+            config["models"] = DEFAULT_GITHUB_MODELS
 
     # Model parameter
-    allow_custom_model = source == "OpenRouter"
+    allow_custom_model = source in ("OpenRouter", "GitHub Models")
     parameters[1].enabled = bool(config["models"]) or allow_custom_model
     if config["models"]:
         if allow_custom_model and current_model and current_model not in config["models"]:

--- a/arcgispro_ai/toolboxes/arcgispro_ai/auth.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/auth.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_CONFIG_DIR = Path.home() / ".arcgispro_ai"
+DEFAULT_GITHUB_MODELS_TOKEN_FILE = DEFAULT_CONFIG_DIR / "github_models_token.txt"
+TOKEN_SETUP_GUIDANCE = (
+    "GitHub Models token not found. Run tools\\auth\\auth_github_models.bat "
+    "to configure authentication."
+)
+
+
+def get_github_models_token_path() -> Path:
+    """Return the configured GitHub Models token file path."""
+    override = os.environ.get("ARCGISPRO_AI_GITHUB_MODELS_TOKEN_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_GITHUB_MODELS_TOKEN_FILE
+
+
+def load_github_models_token(token_path: Optional[str] = None) -> str:
+    """Load the locally stored GitHub Models token."""
+    path = Path(token_path).expanduser() if token_path else get_github_models_token_path()
+
+    try:
+        token_value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise ValueError(TOKEN_SETUP_GUIDANCE) from exc
+    except OSError as exc:
+        raise ValueError(f"Unable to read GitHub Models token file at {path}: {exc}") from exc
+
+    if not token_value:
+        raise ValueError(TOKEN_SETUP_GUIDANCE)
+
+    return token_value

--- a/arcgispro_ai/toolboxes/arcgispro_ai/core/api_clients.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/core/api_clients.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 from typing import Dict, List, Union, Optional, Any
 
 from .model_registry import DEFAULT_OPENROUTER_MODELS
+from ..providers.github_models import GitHubModelsClient
 
 def log_message(message: str):
     """Log message to both console and ArcGIS Pro if available."""
@@ -372,6 +373,7 @@ def get_client(source: str, api_key: str, **kwargs) -> APIClient:
         "Claude": lambda: ClaudeClient(api_key, model=kwargs.get('model', 'claude-3-opus-20240229')),
         "DeepSeek": lambda: DeepSeekClient(api_key, model=kwargs.get('model', 'deepseek-chat')),
         "OpenRouter": lambda: OpenRouterClient(api_key, model=kwargs.get('model', 'openai/gpt-4o')),
+        "GitHub Models": lambda: GitHubModelsClient(api_key, model=kwargs.get("model", "openai/gpt-4.1")),
         "Local LLM": lambda: LocalLLMClient(base_url=kwargs.get('base_url', 'http://localhost:8000')),
         "Wolfram Alpha": lambda: WolframAlphaClient(api_key)
     }

--- a/arcgispro_ai/toolboxes/arcgispro_ai/core/model_registry.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/core/model_registry.py
@@ -15,6 +15,12 @@ VISION_MODEL_HINTS = {
         "anthropic/claude-4.5",
         "meta-llama/llama-3.2-vision",
     ],
+    "GitHub Models": [
+        "gpt-4o",
+        "omni",
+        "vision",
+        "llama-3.2-vision",
+    ],
 }
 
 # Curated OpenRouter model list aligned with the Copilot-style picker.
@@ -41,6 +47,21 @@ OPENROUTER_CURATED_MODELS = [
 
 # Fallback short list for OpenRouter if dynamic catalog fetch fails
 DEFAULT_OPENROUTER_MODELS = OPENROUTER_CURATED_MODELS
+
+
+# Curated GitHub Models options for the toolbox picker.
+GITHUB_MODELS_CURATED_MODELS = [
+    "openai/gpt-4.1",
+    "openai/gpt-4.1-mini",
+    "openai/gpt-4o",
+    "openai/gpt-5-mini",
+    "deepseek/deepseek-r1",
+    "meta/llama-3.2-90b-vision-instruct",
+    "meta/llama-3.3-70b-instruct",
+]
+
+# Fallback short list for GitHub Models.
+DEFAULT_GITHUB_MODELS = GITHUB_MODELS_CURATED_MODELS
 
 
 def model_supports_images(source: str, model: Optional[str] = None) -> bool:

--- a/arcgispro_ai/toolboxes/arcgispro_ai/core/test_api_clients.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/core/test_api_clients.py
@@ -13,12 +13,14 @@ from esri.toolboxes.arcgispro_ai.core.api_clients import (
     AzureOpenAIClient,
     ClaudeClient,
     DeepSeekClient,
+    GitHubModelsClient,
     LocalLLMClient,
     WolframAlphaClient,
     get_client,
     GeoJSONUtils,
     parse_numeric_value
 )
+from arcgispro_ai.toolboxes.arcgispro_ai.core.model_registry import DEFAULT_GITHUB_MODELS
 
 class TestAPIClient(unittest.TestCase):
     def setUp(self):
@@ -226,6 +228,58 @@ class TestLocalLLMClient(unittest.TestCase):
         response = self.client.get_completion(messages, response_format="json_object")
         self.assertEqual(response, "Hello!")
 
+class TestGitHubModelsClient(unittest.TestCase):
+    def setUp(self):
+        self.api_key = "test-github-token"
+        self.client = GitHubModelsClient(self.api_key, model="openai/gpt-4.1")
+
+    @patch.object(GitHubModelsClient, "_post_json")
+    def test_get_completion(self, mock_post_json):
+        mock_post_json.return_value = {
+            "choices": [{"message": {"content": "Hello from GitHub Models!"}}]
+        }
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Say hello!"},
+        ]
+        response = self.client.get_completion(messages)
+        self.assertEqual(response, "Hello from GitHub Models!")
+
+        mock_post_json.assert_called_with(
+            {
+                "model": "openai/gpt-4.1",
+                "messages": messages,
+                "temperature": 0.5,
+                "max_tokens": 4096,
+            }
+        )
+
+    @patch("arcgispro_ai.toolboxes.arcgispro_ai.providers.github_models.request.urlopen")
+    def test_get_available_models_uses_curated_order(self, mock_urlopen):
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps(
+            [
+                {"id": "meta/llama-3.2-90b-vision-instruct"},
+                {"id": "openai/gpt-4.1"},
+                {"id": "openai/gpt-4.1-mini"},
+                {"id": "random/vendor-model"},
+            ]
+        ).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        models = self.client.get_available_models()
+        self.assertEqual(
+            models,
+            ["openai/gpt-4.1", "openai/gpt-4.1-mini", "meta/llama-3.2-90b-vision-instruct"],
+        )
+
+    @patch("arcgispro_ai.toolboxes.arcgispro_ai.providers.github_models.request.urlopen")
+    def test_get_available_models_fallback_when_request_fails(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("network failure")
+        models = self.client.get_available_models()
+        self.assertEqual(models, DEFAULT_GITHUB_MODELS)
+
 class TestWolframAlphaClient(unittest.TestCase):
     def setUp(self):
         self.api_key = os.getenv('WOLFRAM_ALPHA_API_KEY', 'test-api-key')
@@ -284,6 +338,11 @@ class TestGetClient(unittest.TestCase):
         client = get_client("Local LLM", "", base_url="http://localhost:8000")
         self.assertIsInstance(client, LocalLLMClient)
         self.assertEqual(client.base_url, "http://localhost:8000")
+
+    def test_get_github_models_client(self):
+        client = get_client("GitHub Models", self.api_key, model="openai/gpt-4.1")
+        self.assertIsInstance(client, GitHubModelsClient)
+        self.assertEqual(client.model, "openai/gpt-4.1")
 
     def test_get_wolfram_alpha_client(self):
         client = get_client("Wolfram Alpha", self.api_key)

--- a/arcgispro_ai/toolboxes/arcgispro_ai/providers/__init__.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/providers/__init__.py
@@ -1,0 +1,1 @@
+from .github_models import GitHubModelsClient

--- a/arcgispro_ai/toolboxes/arcgispro_ai/providers/github_models.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/providers/github_models.py
@@ -1,0 +1,160 @@
+import json
+import ssl
+import time
+from typing import Any, Dict, List, Optional
+from urllib import error, request
+
+from ..core.model_registry import DEFAULT_GITHUB_MODELS
+
+
+class GitHubModelsClient:
+    """Client for GitHub Models chat completions."""
+
+    def __init__(
+        self,
+        token: str,
+        model: str = "openai/gpt-4.1",
+        endpoint: str = "https://models.github.ai/inference/chat/completions",
+    ):
+        self.token = token
+        self.model = model
+        self.endpoint = endpoint
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def get_available_models(self) -> List[str]:
+        """Get available models from GitHub Models catalog, ordered by curation."""
+        fallback_models = DEFAULT_GITHUB_MODELS
+        req = request.Request(
+            "https://models.github.ai/catalog/models",
+            headers={
+                "Authorization": self.headers["Authorization"],
+                "Accept": "application/json",
+                "X-GitHub-Api-Version": self.headers["X-GitHub-Api-Version"],
+            },
+            method="GET",
+        )
+        ssl_context = ssl.create_default_context()
+
+        try:
+            with request.urlopen(req, timeout=15, context=ssl_context) as response:
+                body = response.read().decode("utf-8")
+                payload = json.loads(body)
+        except Exception:
+            return fallback_models
+
+        if not isinstance(payload, list):
+            return fallback_models
+
+        available_ids = {
+            model.get("id")
+            for model in payload
+            if isinstance(model, dict) and model.get("id")
+        }
+        if not available_ids:
+            return fallback_models
+
+        curated_available = [
+            model_id for model_id in fallback_models if model_id in available_ids
+        ]
+        if curated_available:
+            return curated_available
+
+        # If catalog shape changes or curated IDs drift, still offer a small, stable list.
+        discovered = sorted(str(model_id) for model_id in available_ids if isinstance(model_id, str))
+        return discovered[:20] if discovered else fallback_models
+
+    @staticmethod
+    def _extract_text_content(response: Dict[str, Any]) -> str:
+        choices = response.get("choices", [])
+        if not choices:
+            raise Exception("GitHub Models returned no choices.")
+
+        message = choices[0].get("message", {})
+        content = message.get("content", "")
+
+        if isinstance(content, str):
+            return content.strip()
+
+        if isinstance(content, list):
+            chunks: List[str] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                text_value = item.get("text")
+                if isinstance(text_value, str) and text_value:
+                    chunks.append(text_value)
+            if chunks:
+                return "".join(chunks).strip()
+
+        raise Exception("GitHub Models response did not include text content.")
+
+    def _post_json(
+        self,
+        payload: Dict[str, Any],
+        max_retries: int = 3,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        encoded_payload = json.dumps(payload).encode("utf-8")
+        ssl_context = ssl.create_default_context()
+
+        for attempt in range(max_retries):
+            req = request.Request(
+                self.endpoint,
+                data=encoded_payload,
+                headers=self.headers,
+                method="POST",
+            )
+            try:
+                with request.urlopen(req, timeout=timeout_seconds, context=ssl_context) as response:
+                    body = response.read().decode("utf-8")
+                    return json.loads(body)
+            except error.HTTPError as exc:
+                detail = exc.read().decode("utf-8", errors="replace")
+                if attempt == max_retries - 1:
+                    raise Exception(
+                        f"GitHub Models request failed with status {exc.code}: {detail}"
+                    ) from exc
+            except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+                if attempt == max_retries - 1:
+                    raise Exception(
+                        f"GitHub Models request failed after {max_retries} attempts: {exc}"
+                    ) from exc
+
+            time.sleep(2 ** attempt)
+
+        raise Exception("GitHub Models request failed with an unknown error.")
+
+    def get_completion(
+        self,
+        messages: List[Dict[str, Any]],
+        response_format: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        token_limit = max_tokens if max_tokens is not None else 4096
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.5,
+            "max_tokens": token_limit,
+        }
+
+        if response_format == "json_object":
+            payload["response_format"] = {"type": "json_object"}
+
+        response = self._post_json(payload)
+        return self._extract_text_content(response)
+
+    def get_vision_completion(self, messages: List[Dict[str, Any]], max_tokens: int = 800) -> str:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": 0.2,
+            "max_tokens": max_tokens,
+        }
+        response = self._post_json(payload)
+        return self._extract_text_content(response)

--- a/arcgispro_ai/toolboxes/arcgispro_ai/test_auth.py
+++ b/arcgispro_ai/toolboxes/arcgispro_ai/test_auth.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add the root directory to Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from arcgispro_ai.toolboxes.arcgispro_ai.auth import (
+    get_github_models_token_path,
+    load_github_models_token,
+)
+
+
+class TestGitHubModelsAuth(unittest.TestCase):
+    @patch("pathlib.Path.read_text", return_value="ghp_test_token\n")
+    def test_load_token_from_explicit_path(self, mock_read_text):
+        token = load_github_models_token("C:\\fake\\github_models_token.txt")
+        self.assertEqual(token, "ghp_test_token")
+        mock_read_text.assert_called_once()
+
+    def test_missing_token_file_raises_helpful_error(self):
+        with patch("pathlib.Path.read_text", side_effect=FileNotFoundError):
+            with self.assertRaises(ValueError) as exc:
+                load_github_models_token("C:\\fake\\missing_token.txt")
+            self.assertIn("auth_github_models.bat", str(exc.exception))
+
+    def test_env_override_path(self):
+        token_path = Path("C:/temp/github_models_token.txt")
+        with patch.dict(os.environ, {"ARCGISPRO_AI_GITHUB_MODELS_TOKEN_PATH": str(token_path)}):
+            resolved = get_github_models_token_path()
+            self.assertEqual(resolved, token_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arcgispro_ai/toolboxes/arcgispro_ai_tools.pyt
+++ b/arcgispro_ai/toolboxes/arcgispro_ai_tools.pyt
@@ -68,7 +68,7 @@ class FeatureLayer(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -163,6 +163,7 @@ class FeatureLayer(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -212,7 +213,7 @@ class Field(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM", "Wolfram Alpha"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM", "Wolfram Alpha"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -377,6 +378,7 @@ class Field(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None,
             "Wolfram Alpha": "WOLFRAM_ALPHA_API_KEY"
         }
@@ -534,7 +536,7 @@ class InterpretMap(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -619,6 +621,7 @@ class InterpretMap(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -649,7 +652,7 @@ class InterpretMap(object):
             return
 
         screenshot_info = context.get("screenshot") if context else None
-        provider_supports_vision = source in ("OpenAI", "Azure OpenAI", "OpenRouter")
+        provider_supports_vision = source in ("OpenAI", "Azure OpenAI", "OpenRouter", "GitHub Models")
         model_allows_vision = model_supports_images(source, model) if provider_supports_vision else False
         model_label = model or "current model"
         use_screenshot = bool(include_screenshot) and bool(screenshot_info) and provider_supports_vision and model_allows_vision
@@ -755,7 +758,7 @@ class Python(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -885,6 +888,7 @@ class Python(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -968,9 +972,6 @@ class Python(object):
         """This method takes place after outputs are processed and
         added to the display."""
         return
-    
-
-
 class ConvertTextToNumeric(object):
     def __init__(self):
         """Define the tool (tool name is the name of the class)."""
@@ -989,7 +990,7 @@ class ConvertTextToNumeric(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -1119,6 +1120,7 @@ class ConvertTextToNumeric(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -1197,7 +1199,7 @@ class GenerateTool(object):
             direction="Input",
         )
         source.filter.type = "ValueList"
-        source.filter.list = ["OpenRouter", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
+        source.filter.list = ["OpenRouter", "GitHub Models", "OpenAI", "Azure OpenAI", "Claude", "DeepSeek", "Local LLM"]
         source.value = "OpenRouter"
 
         model = arcpy.Parameter(
@@ -1427,6 +1429,7 @@ class GenerateTool(object):
             "Claude": "ANTHROPIC_API_KEY",
             "DeepSeek": "DEEPSEEK_API_KEY",
             "OpenRouter": "OPENROUTER_API_KEY",
+            "GitHub Models": None,
             "Local LLM": None
         }
         try:
@@ -1562,3 +1565,6 @@ Requirements:
         """This method takes place after outputs are processed and
         added to the display."""
         return
+
+
+

--- a/docs/authentication/github_models.md
+++ b/docs/authentication/github_models.md
@@ -1,0 +1,48 @@
+# GitHub Models Authentication
+
+ArcGIS Pro AI Toolbox supports GitHub Models with a local token workflow.
+
+## Setup
+
+1. Open a terminal in the repository root.
+2. Run:
+
+```bat
+tools\auth\auth_github_models.bat
+```
+
+3. The script opens GitHub's token page.
+4. Create a token with `models` access (or fine-grained `models:read`).
+5. Paste the token into the terminal prompt.
+
+## Token Storage
+
+The token is stored locally at:
+
+```text
+%USERPROFILE%\.arcgispro_ai\github_models_token.txt
+```
+
+The setup script applies restrictive file permissions so only your user account can read the token.
+
+To revoke local access, delete that file.
+
+## Toolbox Usage
+
+Choose:
+
+- `Source`: `GitHub Models`
+- `Model`: for example `openai/gpt-4.1`
+
+The toolbox reads the local token and sends chat completion requests to:
+
+```text
+POST https://models.github.ai/inference/chat/completions
+```
+
+## Troubleshooting
+
+- `GitHub Models token not found...`
+  - Run `tools\auth\auth_github_models.bat` again.
+- `401 Unauthorized`
+  - Verify token scope/permission, expiration, and pasted value.

--- a/tools/auth/auth_github_models.bat
+++ b/tools/auth/auth_github_models.bat
@@ -1,0 +1,40 @@
+@echo off
+setlocal
+
+set "TOKEN_DIR=%USERPROFILE%\.arcgispro_ai"
+set "TOKEN_FILE=%TOKEN_DIR%\github_models_token.txt"
+
+echo.
+echo ArcGIS Pro AI Toolbox - GitHub Models Authentication
+echo.
+echo Opening the GitHub token page in your browser...
+start "" "https://github.com/settings/personal-access-tokens/new"
+echo.
+echo Create a token with models access, then paste it below.
+set /p GITHUB_TOKEN=GitHub token: 
+
+if "%GITHUB_TOKEN%"=="" (
+    echo.
+    echo No token entered. Nothing was saved.
+    exit /b 1
+)
+
+if not exist "%TOKEN_DIR%" (
+    mkdir "%TOKEN_DIR%"
+)
+
+> "%TOKEN_FILE%" (
+    set /p="%GITHUB_TOKEN%"
+)
+
+icacls "%TOKEN_DIR%" /inheritance:r >nul
+icacls "%TOKEN_DIR%" /grant:r "%USERNAME%:(OI)(CI)F" >nul
+icacls "%TOKEN_FILE%" /inheritance:r >nul
+icacls "%TOKEN_FILE%" /grant:r "%USERNAME%:F" >nul
+
+echo.
+echo Saved token to:
+echo %TOKEN_FILE%
+echo.
+echo Setup complete.
+endlocal


### PR DESCRIPTION
## Summary
- add GitHub Models token auth workflow with local token file loading and clear setup errors
- add 	ools/auth/auth_github_models.bat setup script and docs page at docs/authentication/github_models.md
- add GitHub Models provider client using Python standard library HTTP (urllib + ssl) for chat completions
- integrate provider across toolbox source pickers, API key resolution, model wiring, and monolithic build output
- make GitHub Models model picker dynamic by fetching https://models.github.ai/catalog/models and intersecting with curated defaults

## Model picker behavior
- tries live catalog with local token
- keeps curated ordering for stable UX
- falls back to curated defaults if catalog fetch fails
- allows manual custom model IDs in the model field

## Opus 4.6 note
- checked the live GitHub Models catalog on 2026-03-04; it currently returns no Anthropic/Opus IDs
- so Opus 4.6 is not pinned in the GitHub Models curated list right now
- if/when GitHub catalog exposes an Opus ID, we can add it at the top of the curated list immediately

## Validation
- ran unit tests with mocked rcpy: 23 passed
- regenerated rcgispro_ai.pyt and verified syntax compile